### PR TITLE
change java version so it can build

### DIFF
--- a/common/common.xml
+++ b/common/common.xml
@@ -10,7 +10,7 @@
 	<property name="tools" value="../tools"/>
 	<property name="nativelib" value="../common/lib/native"/>
 	<property name="commonstatic" value="../common/static"/>
-	<property name="java_source_version" value="1.6"/>
+	<property name="java_source_version" value="1.7"/>
 
 	<target name="init">
 		<tstamp/>


### PR DESCRIPTION
fixes:
```
wizpig.local $ ant run
Buildfile: /Users/splug/tribaltrouble/tt/build.xml

init:

compile-common:

init:

compiledeps:

compile:
    [javac] /Users/splug/tribaltrouble/common/common.xml:37: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 126 source files to /Users/splug/tribaltrouble/common/build/classes
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 6
    [javac] error: Source option 6 is no longer supported. Use 7 or later.
    [javac] error: Target option 6 is no longer supported. Use 7 or later.

BUILD FAILED
/Users/splug/tribaltrouble/common/common.xml:31: The following error occurred while executing this line:
/Users/splug/tribaltrouble/common/common.xml:37: Compile failed; see the compiler error output for details.

Total time: 0 seconds```